### PR TITLE
Initial Search Filtering

### DIFF
--- a/DataPortal2/src/edu/lternet/pasta/portal/AdvancedSearchServlet.java
+++ b/DataPortal2/src/edu/lternet/pasta/portal/AdvancedSearchServlet.java
@@ -40,43 +40,37 @@ import edu.lternet.pasta.portal.search.SolrAdvancedSearch;
 import edu.lternet.pasta.portal.search.TermsList;
 import edu.lternet.pasta.portal.user.SavedData;
 
-
 public class AdvancedSearchServlet extends DataPortalServlet {
 
   /*
    * Class variables
    */
 
-  private static final Logger logger = Logger
-      .getLogger(edu.lternet.pasta.portal.AdvancedSearchServlet.class);
+  private static final Logger logger = Logger.getLogger(edu.lternet.pasta.portal.AdvancedSearchServlet.class);
   private static final long serialVersionUID = 1L;
 
   private static String cwd = null;
   private static String xslpath = null;
-  
-  
+
   /*
    * Instance variables
    */
-  
-  
+
   /*
    * Constructors
    */
-  
+
   /**
    * Constructor of the object.
    */
   public AdvancedSearchServlet() {
     super();
   }
-  
 
   /*
    * Class methods
    */
 
-  
   /*
    * Instance methods
    */
@@ -89,65 +83,55 @@ public class AdvancedSearchServlet extends DataPortalServlet {
     // Put your code here
   }
 
-  
   /**
    * The doGet method of the servlet. <br>
-   * 
+   *
    * This method is called when a form has its tag value method equals to get.
-   * 
-   * @param request
-   *          the request send by the client to the server
-   * @param response
-   *          the response send by the server to the client
-   * @throws ServletException
-   *           if an error occurred
-   * @throws IOException
-   *           if an error occurred
+   *
+   * @param request  the request send by the client to the server
+   * @param response the response send by the server to the client
+   * @throws ServletException if an error occurred
+   * @throws IOException      if an error occurred
    */
-  public void doGet(HttpServletRequest request, HttpServletResponse response)
-      throws ServletException, IOException {
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 
     doPost(request, response);
 
   }
 
-  
   /**
    * The doPost method of the servlet. <br>
-   * 
+   *
    * This method is called when a form has its tag value method equals to post.
-   * 
-   * @param request
-   *          the request send by the client to the server
-   * @param response
-   *          the response send by the server to the client
-   * @throws ServletException
-   *           if an error occurred
-   * @throws IOException
-   *           if an error occurred
+   *
+   * @param request  the request send by the client to the server
+   * @param response the response send by the server to the client
+   * @throws ServletException if an error occurred
+   * @throws IOException      if an error occurred
    */
-  public void doPost(HttpServletRequest request, HttpServletResponse response)
-      throws ServletException, IOException {
-    
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
     String forward = "./searchResult.jsp";
     String html = "";
     TermsList termsList = null;
-    String termsListHTML= "";
+    String termsListHTML = "";
     String xml = null;
 
     HttpSession httpSession = request.getSession();
-    
+
     String uid = (String) httpSession.getAttribute("uid");
-    
-    if (uid == null || uid.isEmpty()) uid = "public";
-    
+
+    if (uid == null || uid.isEmpty())
+      uid = "public";
+
     String boundaryContained = request.getParameter("boundaryContained");
     String boundsChangedCount = request.getParameter("boundsChangedCount");
     String dateField = request.getParameter("dateField");
     String startDate = request.getParameter("startDate");
     String endDate = request.getParameter("endDate");
     String datesContained = request.getParameter("datesContained");
-    String creatorOrganization = request.getParameter("creatorOrganization");
+    // String creatorOrganization = request.getParameter("creatorOrganization");
+    String creatorOrganization = Search.GIOS_FILTER;
     String creatorName = request.getParameter("creatorName");
     String locationName = request.getParameter("locationName");
     String namedTimescale = request.getParameter("namedTimescale");
@@ -161,12 +145,12 @@ public class AdvancedSearchServlet extends DataPortalServlet {
     String landsat5 = request.getParameter("landsat5");
     String taxon = request.getParameter("taxon");
     String identifier = request.getParameter("identifier");
-    
+
     String northBound = request.getParameter("northBound");
     String southBound = request.getParameter("southBound");
     String eastBound = request.getParameter("eastBound");
     String westBound = request.getParameter("westBound");
-    
+
     boolean isBoundaryContainedChecked = (boundaryContained != null);
     boolean isDatesContainedChecked = (datesContained != null);
     boolean isIncludeEcotrendsChecked = (ecotrends != null);
@@ -174,78 +158,51 @@ public class AdvancedSearchServlet extends DataPortalServlet {
     boolean isSpecificChecked = (specific != null);
     boolean isRelatedChecked = (related != null);
     boolean isRelatedSpecificChecked = (relatedSpecific != null);
-       
-    SolrAdvancedSearch solrAdvancedSearch = new SolrAdvancedSearch(
-      creatorName,
-      creatorOrganization,
-      dateField,
-      startDate,
-      endDate,
-      namedTimescale,
-      siteValues,
-      subjectField,
-      subjectValue,
-      isIncludeEcotrendsChecked,
-      isIncludeLandsat5Checked,
-      isDatesContainedChecked,
-      isSpecificChecked,
-      isRelatedChecked,
-      isRelatedSpecificChecked,
-      taxon,
-      identifier,
-      isBoundaryContainedChecked,
-      boundsChangedCount,
-      northBound,
-      southBound,
-      eastBound,
-      westBound,
-      locationName
-      );
 
-		try {
-			xml = solrAdvancedSearch.executeSearch(uid);
-			String queryText = solrAdvancedSearch.getQueryString();
-			httpSession.setAttribute("queryText", queryText);
+    SolrAdvancedSearch solrAdvancedSearch = new SolrAdvancedSearch(creatorName, creatorOrganization, dateField,
+        startDate, endDate, namedTimescale, siteValues, subjectField, subjectValue, isIncludeEcotrendsChecked,
+        isIncludeLandsat5Checked, isDatesContainedChecked, isSpecificChecked, isRelatedChecked,
+        isRelatedSpecificChecked, taxon, identifier, isBoundaryContainedChecked, boundsChangedCount, northBound,
+        southBound, eastBound, westBound, locationName);
+    try {
+      xml = solrAdvancedSearch.executeSearch(uid);
+      String queryText = solrAdvancedSearch.getQueryString();
+      httpSession.setAttribute("queryText", queryText);
 
-			termsList = solrAdvancedSearch.getTermsList();
-			if ((termsList != null) && (termsList.size() > 0)) {
-				termsListHTML = termsList.toHTML();
-			}
-			else {
-				termsListHTML = "";
-			}
-			httpSession.setAttribute("termsListHTML", termsListHTML);
+      termsList = solrAdvancedSearch.getTermsList();
+      if ((termsList != null) && (termsList.size() > 0)) {
+        termsListHTML = termsList.toHTML();
+      } else {
+        termsListHTML = "";
+      }
+      httpSession.setAttribute("termsListHTML", termsListHTML);
 
-			ResultSetUtility resultSetUtility = null;
-			if (uid.equals("public")) {
-				resultSetUtility = new ResultSetUtility(xml, Search.DEFAULT_SORT);
-			}
-			else {
-				boolean isSavedDataPage = false;
-				SavedData savedData = new SavedData(uid);
-				resultSetUtility = new ResultSetUtility(xml, Search.DEFAULT_SORT, savedData, isSavedDataPage);
-			}
-			
-			String mapButtonHTML = resultSetUtility.getMapButtonHTML();
-			request.setAttribute("mapButtonHTML", mapButtonHTML);
-			//String relevanceHTML = resultSetUtility.getRelevanceHTML();
-			//request.setAttribute("relevanceHTML", relevanceHTML);
-			html = resultSetUtility.xmlToHtmlTable(cwd + xslpath);
-			request.setAttribute("searchresult", html);
-			RequestDispatcher requestDispatcher = request.getRequestDispatcher(forward);
-			requestDispatcher.forward(request, response);
-		}
-		catch (Exception e) {
-			handleDataPortalError(logger, e);
-		}
+      ResultSetUtility resultSetUtility = null;
+      if (uid.equals("public")) {
+        resultSetUtility = new ResultSetUtility(xml, Search.DEFAULT_SORT);
+      } else {
+        boolean isSavedDataPage = false;
+        SavedData savedData = new SavedData(uid);
+        resultSetUtility = new ResultSetUtility(xml, Search.DEFAULT_SORT, savedData, isSavedDataPage);
+      }
+
+      String mapButtonHTML = resultSetUtility.getMapButtonHTML();
+      request.setAttribute("mapButtonHTML", mapButtonHTML);
+      // String relevanceHTML = resultSetUtility.getRelevanceHTML();
+      // request.setAttribute("relevanceHTML", relevanceHTML);
+      html = resultSetUtility.xmlToHtmlTable(cwd + xslpath);
+      request.setAttribute("searchresult", html);
+      RequestDispatcher requestDispatcher = request.getRequestDispatcher(forward);
+      requestDispatcher.forward(request, response);
+    } catch (Exception e) {
+      handleDataPortalError(logger, e);
+    }
   }
 
-  
   /**
    * Initialization of the servlet. <br>
-   * 
-   * @throws ServletException
-   *           if an error occurs
+   *
+   * @throws ServletException if an error occurs
    */
   public void init() throws ServletException {
 
@@ -255,5 +212,5 @@ public class AdvancedSearchServlet extends DataPortalServlet {
     cwd = options.getString("system.cwd");
     logger.debug("CWD: " + cwd);
   }
-  
+
 }

--- a/DataPortal2/src/edu/lternet/pasta/portal/search/Search.java
+++ b/DataPortal2/src/edu/lternet/pasta/portal/search/Search.java
@@ -6,88 +6,83 @@ import java.util.List;
 import org.apache.solr.client.solrj.util.ClientUtils;
 
 /**
- * The Search class contains methods that are common to all search classes,
- * such as SimpleSearch and AdvancedSearch.
- * 
+ * The Search class contains methods that are common to all search classes, such
+ * as SimpleSearch and AdvancedSearch.
+ *
  * @author dcosta
  *
  */
 public class Search {
-	
+
 	/*
 	 * Class variables
 	 */
-	
-	  protected final static String DEFAULT_DEFTYPE = "edismax";
-	  protected final static String DEFAULT_Q_STRING = "*:*";
-	  protected final static String ECOTRENDS_FILTER = "-scope:ecotrends";
-	  protected final static String LANDSAT_FILTER = "-scope:lter-landsat*";
-	  protected final static String DEFAULT_FIELDS = "id,packageid,title,author,organization,pubdate,coordinates";
-	  public final static int DEFAULT_START = 0;
-	  public final static int DEFAULT_ROWS = 10;
-	  protected final static String DEFAULT_DEBUG = "false";
-	  
-	  // Sort values
-	  public final static String CREATORS_SORT = "responsibleParties";
-	  public final static String PACKAGEID_SORT = "packageid";
-	  public final static String PUBDATE_SORT = "pubdate";
-	  public final static String SCORE_SORT = "score";
-	  public final static String TITLE_SORT = "titles";
-	  public final static String SORT_ORDER_ASC = "asc";
-	  public final static String SORT_ORDER_DESC = "desc";
-	  public final static String DEFAULT_SORT_ORDER = SORT_ORDER_DESC;
-	  public final static String DEFAULT_SORT = String.format("%s,%s", SCORE_SORT, SORT_ORDER_DESC);
-	  
-	  
-	  /*
-	   * Instance variables
-	   */
-	  
-	  protected TermsList termsList;
-	  
-	  
-	  /*
-	   * Constructors
-	   */
-	  
-	  public Search () {
-		  this.termsList = new TermsList();
-	  }
-	  
-	  
+
+	protected final static String DEFAULT_DEFTYPE = "edismax";
+	protected final static String DEFAULT_Q_STRING = "*:*";
+	protected final static String ECOTRENDS_FILTER = "-scope:ecotrends";
+	protected final static String LANDSAT_FILTER = "-scope:lter-landsat*";
+	protected final static String GIOS_FILTER = "organization:(\"CAPLTER\") OR organization:(\"CAP LTER\")";
+	protected final static String DEFAULT_FIELDS = "id,packageid,title,author,organization,pubdate,coordinates";
+	public final static int DEFAULT_START = 0;
+	public final static int DEFAULT_ROWS = 10;
+	protected final static String DEFAULT_DEBUG = "false";
+
+	// Sort values
+	public final static String CREATORS_SORT = "responsibleParties";
+	public final static String PACKAGEID_SORT = "packageid";
+	public final static String PUBDATE_SORT = "pubdate";
+	public final static String SCORE_SORT = "score";
+	public final static String TITLE_SORT = "titles";
+	public final static String SORT_ORDER_ASC = "asc";
+	public final static String SORT_ORDER_DESC = "desc";
+	public final static String DEFAULT_SORT_ORDER = SORT_ORDER_DESC;
+	public final static String DEFAULT_SORT = String.format("%s,%s", SCORE_SORT, SORT_ORDER_DESC);
+
+	/*
+	 * Instance variables
+	 */
+
+	protected TermsList termsList;
+
+	/*
+	 * Constructors
+	 */
+
+	public Search() {
+		this.termsList = new TermsList();
+	}
+
 	/*
 	 * Class methods
 	 */
-	  
-	  /**
-	   * Calls the ClientUtils.escapeQueryChars method but does some
-	   * post-processing by removing escaped spaces and double-quotes. 
-	   * This helps support phrase queries such as "coral reef".
-	   * 
-	   * @param queryString   The query string
-	   * @return escapedString, The escaped query string
-	   */
-	  public static String escapeQueryChars(String queryString) {
-		  String escapedString = ClientUtils.escapeQueryChars(queryString);
-		  if (escapedString != null) {
-			  escapedString = escapedString.replace("\\ ", " "); // don't escape spaces
-			  escapedString = escapedString.replace("\\\"", "\""); // don't escape double quotes
-			  escapedString = escapedString.replace("\\(", "("); // don't escape parens
-			  escapedString = escapedString.replace("\\)", ")"); // don't escape parens
-		  }
-		  return escapedString;
-	  }
-	  
+
+	/**
+	 * Calls the ClientUtils.escapeQueryChars method but does some post-processing
+	 * by removing escaped spaces and double-quotes. This helps support phrase
+	 * queries such as "coral reef".
+	 *
+	 * @param queryString The query string
+	 * @return escapedString, The escaped query string
+	 */
+	public static String escapeQueryChars(String queryString) {
+		String escapedString = ClientUtils.escapeQueryChars(queryString);
+		if (escapedString != null) {
+			escapedString = escapedString.replace("\\ ", " "); // don't escape spaces
+			escapedString = escapedString.replace("\\\"", "\""); // don't escape double quotes
+			escapedString = escapedString.replace("\\(", "("); // don't escape parens
+			escapedString = escapedString.replace("\\)", ")"); // don't escape parens
+		}
+		return escapedString;
+	}
 
 	/**
 	 * Adds a string to a list of terms. An auxiliary method to the
 	 * parseTermsAdvanced() method.
-	 * 
-	 * @param terms
-	 *            list of term strings.
-	 * @param term
-	 *            the new string to add to the list, but only if it isn't an
-	 *            empty string.
+	 *
+	 * @param terms list of term strings.
+	 * @param term  the new string to add to the list, but only if it isn't an empty
+	 *              string.
 	 */
 	private static void addTerm(List<String> terms, final String term) {
 		if (term != null) {
@@ -98,15 +93,13 @@ public class Search {
 			}
 		}
 	}
-	  
-	  
+
 	/**
-	 * Parses search terms from a string. Double-quoted strings that contain
-	 * spaces are parsed as a single term.
-	 * 
-	 * @param value
-	 *            The string value as entered by the user.
-	 * 
+	 * Parses search terms from a string. Double-quoted strings that contain spaces
+	 * are parsed as a single term.
+	 *
+	 * @param value The string value as entered by the user.
+	 *
 	 * @return terms An ArrayList of String objects. Each string is a term.
 	 */
 	protected static List<String> parseTerms(String value) {
@@ -123,8 +116,9 @@ public class Search {
 			c = value.charAt(i);
 
 			if (c == '\"') {
-				/* Termination of a quote-enclosed term. Add the current term to
-				 * list and start a new term.
+				/*
+				 * Termination of a quote-enclosed term. Add the current term to list and start
+				 * a new term.
 				 */
 				if (keepWhitespace) {
 					String phraseTerm = String.format("\"%s\"", currentTerm.toString());
@@ -133,23 +127,20 @@ public class Search {
 				}
 
 				keepWhitespace = !(keepWhitespace); // Toggle keepWhitespace
-			}
-			else
-				if (Character.isWhitespace(c)) {
-					// If we are inside a quote-enclosed term, append the whitespace char.
-					if (keepWhitespace) {
-						currentTerm.append(c);
-					}
-					// Else, add the current term to the list and start a new term.
-					else {
-						addTerm(terms, currentTerm.toString());
-						currentTerm = new StringBuffer();
-					}
-				}
-				else {
-					// Append any non-quote, non-space characters to the current term.
+			} else if (Character.isWhitespace(c)) {
+				// If we are inside a quote-enclosed term, append the whitespace char.
+				if (keepWhitespace) {
 					currentTerm.append(c);
 				}
+				// Else, add the current term to the list and start a new term.
+				else {
+					addTerm(terms, currentTerm.toString());
+					currentTerm = new StringBuffer();
+				}
+			} else {
+				// Append any non-quote, non-space characters to the current term.
+				currentTerm.append(c);
+			}
 		}
 
 		// Add the final term to the list.
@@ -157,32 +148,30 @@ public class Search {
 
 		return terms;
 	}
-	
-	
+
 	/*
 	 * Instance methods
 	 */
-	
+
 	/**
 	 * Accessor method for termsList
-	 * 
+	 *
 	 * @return termsList
 	 */
 	public TermsList getTermsList() {
 		return termsList;
 	}
 
-	
 	/**
 	 * Wraps parens around a query value if it needs them.
-	 * 
+	 *
 	 * For example, the two Solr queries below have different meanings:
-	 * 
-	 * author:jones bug     matches authors named "jones" or text containing "bug"
-	 *                      because the second term is matched against the default
-	 *                      field (df), which in our case is the text field
-	 * author:(jones bug)   matches authors named "jones" or authors named "bug"
-	 * 
+	 *
+	 * author:jones bug matches authors named "jones" or text containing "bug"
+	 * because the second term is matched against the default field (df), which in
+	 * our case is the text field author:(jones bug) matches authors named "jones"
+	 * or authors named "bug"
+	 *
 	 * @return termsList
 	 */
 	public String parenthesizeQueryValue(String value) {

--- a/DataPortal2/src/edu/lternet/pasta/portal/search/SimpleSearch.java
+++ b/DataPortal2/src/edu/lternet/pasta/portal/search/SimpleSearch.java
@@ -31,9 +31,9 @@ import java.util.List;
 import org.apache.log4j.Logger;
 
 /**
- * The SimpleSearch class supports query operations common to the simple
- * search and browse search interfaces.
- * 
+ * The SimpleSearch class supports query operations common to the simple search
+ * and browse search interfaces.
+ *
  * @author dcosta
  *
  */
@@ -43,60 +43,63 @@ public class SimpleSearch extends Search {
 	 * Class fields
 	 */
 
-    private static final Logger logger = Logger.getLogger(SimpleSearch.class);
+	private static final Logger logger = Logger.getLogger(SimpleSearch.class);
 
-	  
-  /**
-   * Builds a query for submission to the DataPackageManager
-   * and then to Solr.
-   * 
-   * @param userInput    The terms entered by the user (e.g. "climate change")
-   * @param termsList    List of terms used in the search, which may include terms other
-   * @param isSiteQuery  true if we are querying by site name, else false.
-   * 
-   *                     When true, the user input is being sent from the browse crawler
-   *                     and its value will be a site acronym like "KNZ".
-   *                     
-   *                     When false, the user input is being sent from the search form
-   *                     and will be anything that the end user has typed in the search box,
-   *                     or, it may be a controlled vocabulary term sent from the browse
-   *                     crawler. 
-   * @return the Solr query string, including any filter queries, to be sent to Solr
-   *         for processing
-   */
+	/**
+	 * Builds a query for submission to the DataPackageManager and then to Solr.
+	 *
+	 * @param userInput   The terms entered by the user (e.g. "climate change")
+	 * @param termsList   List of terms used in the search, which may include terms
+	 *                    other
+	 * @param isSiteQuery true if we are querying by site name, else false.
+	 *
+	 *                    When true, the user input is being sent from the browse
+	 *                    crawler and its value will be a site acronym like "KNZ".
+	 *
+	 *                    When false, the user input is being sent from the search
+	 *                    form and will be anything that the end user has typed in
+	 *                    the search box, or, it may be a controlled vocabulary term
+	 *                    sent from the browse crawler.
+	 * @return the Solr query string, including any filter queries, to be sent to
+	 *         Solr for processing
+	 */
 	public String buildSolrQuery(String userInput, boolean isSiteQuery) {
 		String solrQuery = null;
 		String qString = DEFAULT_Q_STRING;
 		String siteFilter = "";
+		String giosEncodedFilter = "";
 		List<String> terms;
 
 		if (userInput != null && !userInput.equals("")) {
 			terms = parseTerms(userInput);
-			
+
 			for (String term : terms) {
 				termsList.addTerm(term);
 			}
-			
+
 			try {
 				if (isSiteQuery) {
 					siteFilter = String.format("&fq=scope:(knb-lter-%s)", userInput.toLowerCase());
-				}
-				else {
+				} else {
 					String escapedInput = Search.escapeQueryChars(userInput);
 					qString = URLEncoder.encode(escapedInput, "UTF-8");
 				}
-			}
-			catch (UnsupportedEncodingException e) {
+			} catch (UnsupportedEncodingException e) {
 
 			}
-			
-			solrQuery = String.format(
-					"defType=%s&q=%s%s&fq=%s&fq=%s&fl=%s&debug=%s",
-					DEFAULT_DEFTYPE, qString, siteFilter, ECOTRENDS_FILTER,
-					LANDSAT_FILTER, DEFAULT_FIELDS, DEFAULT_DEBUG);
+
+			// supply a filter query to limit our search to just the organization(s) we want
+			try {
+				giosEncodedFilter = URLEncoder.encode(GIOS_FILTER, "UTF-8");
+			} catch (UnsupportedEncodingException e) {
+
+			}
+
+			solrQuery = String.format("defType=%s&q=%s%s&fq=%s&fq=%s&fq=%s&fl=%s&debug=%s", DEFAULT_DEFTYPE, qString,
+					siteFilter, giosEncodedFilter, ECOTRENDS_FILTER, LANDSAT_FILTER, DEFAULT_FIELDS, DEFAULT_DEBUG);
 		}
 
 		return solrQuery;
 	}
-  
+
 }

--- a/DataPortal2/src/edu/lternet/pasta/portal/search/SolrAdvancedSearch.java
+++ b/DataPortal2/src/edu/lternet/pasta/portal/search/SolrAdvancedSearch.java
@@ -167,7 +167,7 @@ public class SolrAdvancedSearch extends Search {
       // our filter contains reserved characters, so URL encode them
       giosEncodedFilter = URLEncoder.encode(GIOS_FILTER, "UTF-8");
     } catch (UnsupportedEncodingException e) {
-      // do stuff here
+
     }
 
     String giosFilter = String.format("&fq=%s", giosEncodedFilter);

--- a/DataPortal2/src/edu/lternet/pasta/portal/search/SolrAdvancedSearch.java
+++ b/DataPortal2/src/edu/lternet/pasta/portal/search/SolrAdvancedSearch.java
@@ -40,29 +40,27 @@ import edu.lternet.pasta.client.PastaClient;
 import edu.lternet.pasta.common.ISO8601Utility;
 import edu.lternet.pasta.portal.search.LTERSite;
 
-
 /**
- * AdvancedSearch class constructs queries that use the pathquery feature of 
+ * AdvancedSearch class constructs queries that use the pathquery feature of
  * Metacat. It can execute either an advanced search, where the user fills in
  * fields in a web form, or a simple search on a string.
  */
-public class SolrAdvancedSearch extends Search  {
-  
+public class SolrAdvancedSearch extends Search {
+
   /*
    * Class fields
    */
 
-	private static final Logger logger = Logger.getLogger(SolrAdvancedSearch.class);
+  private static final Logger logger = Logger.getLogger(SolrAdvancedSearch.class);
 
-  
   /*
    * Instance fields
    */
-  
+
   /*
    * Form parameters
    */
-	
+
   private final String creatorOrganization;
   private final String creatorName;
   private final String dateField;
@@ -78,7 +76,7 @@ public class SolrAdvancedSearch extends Search  {
   private boolean includeLandsat5;
   private String taxon;
   private String identifier;
-  
+
   private boolean isBoundaryContainedChecked;
   private String boundsChangedCount;
   private String northBound;
@@ -86,7 +84,7 @@ public class SolrAdvancedSearch extends Search  {
   private String eastBound;
   private String westBound;
   private String locationName;
- 
+
   private String queryString;
   private String qString;
   private String fqString;
@@ -98,7 +96,6 @@ public class SolrAdvancedSearch extends Search  {
   private boolean hasNarrowRelated = false;
   private boolean hasAll = false;
 
-  
   /*
    * Constructors
    */
@@ -106,33 +103,13 @@ public class SolrAdvancedSearch extends Search  {
   /**
    * Constructor. Passes in a large set of form field parameters.
    */
-  public SolrAdvancedSearch(
-	  String creatorName,
-      String creatorOrganization,
-      String dateField,
-      String startDate,
-      String endDate,
-      String namedTimescale,
-      String[] siteValues,
-      String subjectField,
-      String subjectValue,
-      boolean isIncludeEcotrendsChecked,
-      boolean isIncludeLandsat5Checked,
-      boolean isDatesContainedChecked,
-      boolean isSpecificChecked,
-      boolean isRelatedChecked,
-      boolean isRelatedSpecificChecked,
-      String taxon,
-      String identifier,
-      boolean isBoundaryContainedChecked,
-      String boundsChangedCount,
-      String northBound,
-      String southBound,
-      String eastBound,
-      String westBound,
-      String locationName
-                       ) {
-	super();
+  public SolrAdvancedSearch(String creatorName, String creatorOrganization, String dateField, String startDate,
+      String endDate, String namedTimescale, String[] siteValues, String subjectField, String subjectValue,
+      boolean isIncludeEcotrendsChecked, boolean isIncludeLandsat5Checked, boolean isDatesContainedChecked,
+      boolean isSpecificChecked, boolean isRelatedChecked, boolean isRelatedSpecificChecked, String taxon,
+      String identifier, boolean isBoundaryContainedChecked, String boundsChangedCount, String northBound,
+      String southBound, String eastBound, String westBound, String locationName) {
+    super();
     this.creatorName = creatorName;
     this.creatorOrganization = creatorOrganization;
     this.dateField = dateField;
@@ -147,7 +124,7 @@ public class SolrAdvancedSearch extends Search  {
     this.includeLandsat5 = isIncludeLandsat5Checked;
     this.taxon = taxon;
     this.identifier = identifier;
-    
+
     this.isBoundaryContainedChecked = isBoundaryContainedChecked;
     this.boundsChangedCount = boundsChangedCount;
     this.northBound = northBound;
@@ -155,43 +132,55 @@ public class SolrAdvancedSearch extends Search  {
     this.eastBound = eastBound;
     this.westBound = westBound;
     this.locationName = locationName;
-    
+
     this.hasExact = !isSpecificChecked && !isRelatedChecked && !isRelatedSpecificChecked;
     this.hasNarrow = isSpecificChecked && !isRelatedChecked && !isRelatedSpecificChecked;
     this.hasRelated = !isSpecificChecked && isRelatedChecked && !isRelatedSpecificChecked;
     this.hasNarrowRelated = isSpecificChecked && isRelatedChecked && !isRelatedSpecificChecked;
     this.hasAll = isRelatedSpecificChecked;
-    
+
     this.qString = DEFAULT_Q_STRING;
     this.fqString = initializeFilterQuery(includeEcotrends, includeLandsat5);
   }
-  
-  
+
   /*
    * Instance methods
    */
-  
+
   /*
    * Composes the filter query string for advanced search as determined by whether
    * the user has chosen to include optional content for Ecotrends or Landsat5.
    */
   private String initializeFilterQuery(boolean includeEcotrends, boolean includeLandsat5) {
-	  StringBuilder sb = new StringBuilder("");
-	  if (!includeEcotrends) { sb.append(String.format("fq=%s", ECOTRENDS_FILTER)); }
-	  if (!includeLandsat5) { 
-		  String prefix = includeEcotrends ? "" : "&";
-		  sb.append(String.format("%sfq=%s", prefix, LANDSAT_FILTER)); 
-	  }
-	  String filterQuery = sb.toString();
-	  return filterQuery;
+    String giosEncodedFilter = "";
+    StringBuilder sb = new StringBuilder("");
+    if (!includeEcotrends) {
+      sb.append(String.format("fq=%s", ECOTRENDS_FILTER));
+    }
+    if (!includeLandsat5) {
+      String prefix = includeEcotrends ? "" : "&";
+      sb.append(String.format("%sfq=%s", prefix, LANDSAT_FILTER));
+    }
+
+    // always add a query filter to limit results to our desired organization(s)
+    try {
+      // our filter contains reserved characters, so URL encode them
+      giosEncodedFilter = URLEncoder.encode(GIOS_FILTER, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      // do stuff here
+    }
+
+    String giosFilter = String.format("&fq=%s", giosEncodedFilter);
+    sb.append(giosFilter);
+
+    String filterQuery = sb.toString();
+    return filterQuery;
   }
 
-  
   /*
    * Class methods
    */
 
-  
   /*
    * Instance methods
    */
@@ -200,257 +189,215 @@ public class SolrAdvancedSearch extends Search  {
    * A full subject query searches the title, abstract, and keyword sections of
    * the document. Individual searches on these sections is also supported.
    */
-	private void buildQuerySubject(TermsList termsList) 
-		 throws UnsupportedEncodingException {
-		List<String> terms;
-		String field = "subject";
+  private void buildQuerySubject(TermsList termsList) throws UnsupportedEncodingException {
+    List<String> terms;
+    String field = "subject";
 
-		if ((this.subjectValue != null) && (!(this.subjectValue.equals("")))) {
-			if (subjectField.equals("ABSTRACT")) {
-				field = "abstract";
-			}
-			else if (subjectField.equals("KEYWORDS")) {
-				field = "keyword";
-			}
-			else if (subjectField.equals("TITLE")) {
-				field = "title";
-			}
+    if ((this.subjectValue != null) && (!(this.subjectValue.equals("")))) {
+      if (subjectField.equals("ABSTRACT")) {
+        field = "abstract";
+      } else if (subjectField.equals("KEYWORDS")) {
+        field = "keyword";
+      } else if (subjectField.equals("TITLE")) {
+        field = "title";
+      }
 
-			terms = parseTerms(this.subjectValue);
+      terms = parseTerms(this.subjectValue);
 
-			TreeSet<String> derivedTerms = new TreeSet<String>();
-			
-			for (String term : terms) {
-				derivedTerms.add(term);
-				
-				TreeSet<String> webTerms = 
-						ControlledVocabularyClient.webServiceSearchValues(
-								term, hasExact, hasNarrow, hasRelated, hasNarrowRelated, hasAll);
+      TreeSet<String> derivedTerms = new TreeSet<String>();
 
-				for (String webTerm : webTerms) {
-					derivedTerms.add(webTerm);
-				}
-			}
+      for (String term : terms) {
+        derivedTerms.add(term);
 
-			String subjectQuery = "";
-			boolean firstTerm = true;
-			for (String derivedTerm : derivedTerms) {
-				termsList.addTerm(derivedTerm);
-				if (!firstTerm) {
-					subjectQuery += "%20OR%20";
-				}
-				else {
-					firstTerm = false;
-				}
-				String parenthesizedValue = parenthesizeQueryValue(derivedTerm);
-				String escapedTerms = Search.escapeQueryChars(parenthesizedValue);
-				String encodedTerms = URLEncoder.encode(escapedTerms, "UTF-8");
-				subjectQuery += String.format("%s:%s", field, encodedTerms);
-			}
+        TreeSet<String> webTerms = ControlledVocabularyClient.webServiceSearchValues(term, hasExact, hasNarrow,
+            hasRelated, hasNarrowRelated, hasAll);
 
-			updateQString(subjectQuery);
-		}
-	}
-	
-	
-	private void updateQString(String qText) {
-		if (this.qString.equals(DEFAULT_Q_STRING)) {
-			this.qString = qText;
-		}
-		else {
-			this.qString = String.format("%s+%s", this.qString, qText);
-		}
-	}
+        for (String webTerm : webTerms) {
+          derivedTerms.add(webTerm);
+        }
+      }
 
+      String subjectQuery = "";
+      boolean firstTerm = true;
+      for (String derivedTerm : derivedTerms) {
+        termsList.addTerm(derivedTerm);
+        if (!firstTerm) {
+          subjectQuery += "%20OR%20";
+        } else {
+          firstTerm = false;
+        }
+        String parenthesizedValue = parenthesizeQueryValue(derivedTerm);
+        String escapedTerms = Search.escapeQueryChars(parenthesizedValue);
+        String encodedTerms = URLEncoder.encode(escapedTerms, "UTF-8");
+        subjectQuery += String.format("%s:%s", field, encodedTerms);
+      }
 
-	private void updateFQString(String fqText) {
-		this.fqString = String.format("%s&fq=%s", this.fqString, fqText);
-	}
+      updateQString(subjectQuery);
+    }
+  }
 
+  private void updateQString(String qText) {
+    if (this.qString.equals(DEFAULT_Q_STRING)) {
+      this.qString = qText;
+    } else {
+      this.qString = String.format("%s+%s", this.qString, qText);
+    }
+  }
+
+  private void updateFQString(String fqText) {
+    this.fqString = String.format("%s&fq=%s", this.fqString, fqText);
+  }
 
   /**
    * An author query will search on the creator name and/or creator organization.
    */
-  private void buildQueryAuthor(TermsList termsList) 
-          throws UnsupportedEncodingException {
+  private void buildQueryAuthor(TermsList termsList) throws UnsupportedEncodingException {
 
     if (this.creatorName != null && !this.creatorName.equals("")) {
-        termsList.addTerm(this.creatorName);
-        String searchName = this.creatorName;
-        String escapedSearchName = Search.escapeQueryChars(searchName);
-        String authorQuery = "author:(\"" + escapedSearchName + "\")";
-        String encodedValue = URLEncoder.encode(authorQuery, "UTF-8");
-        updateQString(encodedValue);
+      termsList.addTerm(this.creatorName);
+      String searchName = this.creatorName;
+      String escapedSearchName = Search.escapeQueryChars(searchName);
+      String authorQuery = "author:(\"" + escapedSearchName + "\")";
+      String encodedValue = URLEncoder.encode(authorQuery, "UTF-8");
+      updateQString(encodedValue);
     }
+    /*
+     * if (this.creatorOrganization != null && !this.creatorOrganization.equals(""))
+     * { termsList.addTerm(this.creatorOrganization); String searchName =
+     * this.creatorOrganization; String escapedSearchName =
+     * Search.escapeQueryChars(searchName); String organizationQuery =
+     * "organization:(\"" + escapedSearchName + "\")"; String encodedValue =
+     * URLEncoder.encode(organizationQuery, "UTF-8"); updateQString(encodedValue); }
+     */
 
-    if (this.creatorOrganization != null && !this.creatorOrganization.equals("")) {
-        termsList.addTerm(this.creatorOrganization);
-        String searchName = this.creatorOrganization;
-        String escapedSearchName = Search.escapeQueryChars(searchName);
-        String organizationQuery = "organization:(\"" + escapedSearchName + "\")";
-        String encodedValue = URLEncoder.encode(organizationQuery, "UTF-8");
-        updateQString(encodedValue);
-    }
-    
   }
-  
 
   /**
    * Builds query group for a search on a specific named location.
    */
-  private void buildQueryGeographicDescription(String locationName, TermsList termsList) 
-  		throws UnsupportedEncodingException {
-		if ((locationName != null) && (!(locationName.equals("")))) {
-			String parenthesizedValue = parenthesizeQueryValue(locationName);
-			termsList.addTerm(locationName);
-			String escapedValue = Search.escapeQueryChars(parenthesizedValue);
-			String encodedValue = URLEncoder.encode(escapedValue, "UTF-8");
-			String locationQuery = String.format("geographicdescription:%s",
-					encodedValue);
-			updateQString(locationQuery);
-		}
+  private void buildQueryGeographicDescription(String locationName, TermsList termsList)
+      throws UnsupportedEncodingException {
+    if ((locationName != null) && (!(locationName.equals("")))) {
+      String parenthesizedValue = parenthesizeQueryValue(locationName);
+      termsList.addTerm(locationName);
+      String escapedValue = Search.escapeQueryChars(parenthesizedValue);
+      String encodedValue = URLEncoder.encode(escapedValue, "UTF-8");
+      String locationQuery = String.format("geographicdescription:%s", encodedValue);
+      updateQString(locationQuery);
+    }
   }
-  
-  
+
   /**
    * Builds query group for spatial search on north/south/east/west bounding
-   * coordinates. Includes logic to handle queries across the international
-   * date line.
+   * coordinates. Includes logic to handle queries across the international date
+   * line.
    */
-	private void buildQueryFilterSpatial(String northValue, String southValue,
-			String eastValue, String westValue, boolean boundaryContained) 
-		throws UnsupportedEncodingException {
-		boolean crosses;
-		final String shapeOperation = boundaryContained ? "IsWithin" : "Intersects";
+  private void buildQueryFilterSpatial(String northValue, String southValue, String eastValue, String westValue,
+      boolean boundaryContained) throws UnsupportedEncodingException {
+    boolean crosses;
+    final String shapeOperation = boundaryContained ? "IsWithin" : "Intersects";
 
-		northValue = validateGeographicCoordinate(northValue, -90.0F, 90.0F, "90.0");
-		southValue = validateGeographicCoordinate(southValue, -90.0F, 90.0F, "-90.0");
-		eastValue = validateGeographicCoordinate(eastValue, -180.0F, 180.0F, "180.0");
-		westValue = validateGeographicCoordinate(westValue, -180.0F, 180.0F, "-180.0");
+    northValue = validateGeographicCoordinate(northValue, -90.0F, 90.0F, "90.0");
+    southValue = validateGeographicCoordinate(southValue, -90.0F, 90.0F, "-90.0");
+    eastValue = validateGeographicCoordinate(eastValue, -180.0F, 180.0F, "180.0");
+    westValue = validateGeographicCoordinate(westValue, -180.0F, 180.0F, "-180.0");
 
-		/*
-		 * Check that all four coordinates has values before attempting spatial
-		 * search.
-		 */
-		if ((northValue != null) && (!(northValue.equals("")))
-				&& (southValue != null) && (!(southValue.equals("")))
-				&& (eastValue != null) && (!(eastValue.equals("")))
-				&& (westValue != null) && (!(westValue.equals("")))
-			) {
+    /*
+     * Check that all four coordinates has values before attempting spatial search.
+     */
+    if ((northValue != null) && (!(northValue.equals(""))) && (southValue != null) && (!(southValue.equals("")))
+        && (eastValue != null) && (!(eastValue.equals(""))) && (westValue != null) && (!(westValue.equals("")))) {
 
-			boolean changed = boundsWereChanged(boundsChangedCount, northValue, southValue, eastValue, westValue);
-			if (!changed) {
-				return;
-			}
+      boolean changed = boundsWereChanged(boundsChangedCount, northValue, southValue, eastValue, westValue);
+      if (!changed) {
+        return;
+      }
 
-			/*
-			 * Check whether the east/west coordinates cross over the
-			 * international dateline. If the search crosses the dateline,
-			 * special handling will be needed in forming the query.
-			 */
-			crosses = crossesInternationalDateline(eastValue, westValue);
+      /*
+       * Check whether the east/west coordinates cross over the international
+       * dateline. If the search crosses the dateline, special handling will be needed
+       * in forming the query.
+       */
+      crosses = crossesInternationalDateline(eastValue, westValue);
 
-			if (crosses) {
-				// Not sure yet how to manage international date-line queries in Solr
-			}
-			
-			String spatialFilter = String.format("coordinates:\"%s(%s %s %s %s)\"", 
-					                             shapeOperation, westValue, southValue, eastValue, northValue);
-			String encodedSpatialFilter = URLEncoder.encode(spatialFilter, "UTF-8");
-			updateFQString(encodedSpatialFilter);
-		}
-	}
-  
+      if (crosses) {
+        // Not sure yet how to manage international date-line queries in Solr
+      }
 
-	/*
-	 * Boolean to determine whether the user changed the boundary values. Google Maps
-	 * makes this very hard to determine since they seem to keep changing the default
-	 * values from underneath us. Even when the map isn't touched, we register a
-	 * boundsChangedCount value of 2, so we need to check for 3 changes or greater to ensure
-	 * that the user actually changed the value. Google sets the north to 84.67
-	 * and south to -84.67. Very problematic, so the best we can hope for is a kludge
-	 * that will work most of the time.
-	 */
-	private boolean boundsWereChanged(String boundsChangedCount, 
-			                          String northValue,
-			                          String southValue,
-			                          String eastValue,
-			                          String westValue) {
-		boolean changed = false;
-		
-		int count = Integer.valueOf(boundsChangedCount);
-		float north = Float.valueOf(northValue);
-		float south = Float.valueOf(southValue);
-		float east = Float.valueOf(eastValue);
-		float west = Float.valueOf(westValue);
-		
-		if ((count >= 3) ||
-			(north < 84.0) || 
-			(south > -84.0) || 
-			(east < 180.0) || 
-			(west > -180.0)
-		   ) {
-			changed = true;
-		}
-
-		return changed;
-	}
-  
+      String spatialFilter = String.format("coordinates:\"%s(%s %s %s %s)\"", shapeOperation, westValue, southValue,
+          eastValue, northValue);
+      String encodedSpatialFilter = URLEncoder.encode(spatialFilter, "UTF-8");
+      updateFQString(encodedSpatialFilter);
+    }
+  }
 
   /*
-   * Helper method to implement server-side validation of geographic coordinate values.
+   * Boolean to determine whether the user changed the boundary values. Google
+   * Maps makes this very hard to determine since they seem to keep changing the
+   * default values from underneath us. Even when the map isn't touched, we
+   * register a boundsChangedCount value of 2, so we need to check for 3 changes
+   * or greater to ensure that the user actually changed the value. Google sets
+   * the north to 84.67 and south to -84.67. Very problematic, so the best we can
+   * hope for is a kludge that will work most of the time.
    */
-  private String validateGeographicCoordinate(String stringValue, 
-                                              float minValue, 
-                                              float maxValue, 
-                                              String defaultValue) {
+  private boolean boundsWereChanged(String boundsChangedCount, String northValue, String southValue, String eastValue,
+      String westValue) {
+    boolean changed = false;
+
+    int count = Integer.valueOf(boundsChangedCount);
+    float north = Float.valueOf(northValue);
+    float south = Float.valueOf(southValue);
+    float east = Float.valueOf(eastValue);
+    float west = Float.valueOf(westValue);
+
+    if ((count >= 3) || (north < 84.0) || (south > -84.0) || (east < 180.0) || (west > -180.0)) {
+      changed = true;
+    }
+
+    return changed;
+  }
+
+  /*
+   * Helper method to implement server-side validation of geographic coordinate
+   * values.
+   */
+  private String validateGeographicCoordinate(String stringValue, float minValue, float maxValue, String defaultValue) {
     String returnValue = defaultValue;
-    String warning = "Illegal geographic coordinate specified: '" + stringValue +
-                     "'. Expected a value between " + minValue + " and " + maxValue;
+    String warning = "Illegal geographic coordinate specified: '" + stringValue + "'. Expected a value between "
+        + minValue + " and " + maxValue;
 
     if (stringValue == null || stringValue.equals("")) {
       return returnValue;
-    }
-    else {
+    } else {
       try {
         Float floatValue = new Float(stringValue);
 
-        if ((floatValue != null) &&
-            (floatValue >= minValue) && 
-            (floatValue <= maxValue)) {
+        if ((floatValue != null) && (floatValue >= minValue) && (floatValue <= maxValue)) {
           returnValue = stringValue;
-        }
-        else {
+        } else {
           logger.warn(warning);
         }
-      }
-      catch (NumberFormatException e) {
+      } catch (NumberFormatException e) {
         logger.warn(warning);
       }
     }
-    
+
     return returnValue;
   }
-  
 
   /**
-   * Two kinds of temporal searches are supported. The first is on a named
-   * time scale. The second is on a specific start date and/or end date.
+   * Two kinds of temporal searches are supported. The first is on a named time
+   * scale. The second is on a specific start date and/or end date.
    */
-  private void buildQueryFilterTemporal(String dateField,
-                                          String startDate,
-                                          String endDate,
-                                          boolean isDatesContainedChecked,
-                                          String namedTimescale, 
-                                          String namedTimescaleQueryType,
-                                          TermsList termsList
-                                         ) 
-  		throws UnsupportedEncodingException {
-	  boolean endDateSpecified = false;
-	  boolean startDateSpecified = false;
-	  
-    /* If the user specified a named time-scale query, search for it
-     * in the "timescale" field.
+  private void buildQueryFilterTemporal(String dateField, String startDate, String endDate,
+      boolean isDatesContainedChecked, String namedTimescale, String namedTimescaleQueryType, TermsList termsList)
+      throws UnsupportedEncodingException {
+    boolean endDateSpecified = false;
+    boolean startDateSpecified = false;
+
+    /*
+     * If the user specified a named time-scale query, search for it in the
+     * "timescale" field.
      */
     if ((namedTimescale != null) && (!(namedTimescale.equals("")))) {
       termsList.addTerm(namedTimescale);
@@ -460,62 +407,59 @@ public class SolrAdvancedSearch extends Search  {
       String timescaleQuery = String.format("timescale:%s", encodedValue);
       updateQString(timescaleQuery);
     }
-    
+
     if ((startDate == null) || (startDate.equals(""))) {
-    	startDate = "*";
-    }
-    else {
-        startDate = ISO8601Utility.formatTimestamp(startDate, "DAY");
-        if (startDate != null) startDateSpecified = true;
+      startDate = "*";
+    } else {
+      startDate = ISO8601Utility.formatTimestamp(startDate, "DAY");
+      if (startDate != null)
+        startDateSpecified = true;
     }
 
     if ((endDate == null) || (endDate.equals(""))) {
-    	endDate = "NOW";
-    }
-    else {
-    	endDate = ISO8601Utility.formatTimestamp(endDate, "DAY");
-    	if (endDate != null) endDateSpecified = true;
+      endDate = "NOW";
+    } else {
+      endDate = ISO8601Utility.formatTimestamp(endDate, "DAY");
+      if (endDate != null)
+        endDateSpecified = true;
     }
 
     validateDateRange(startDate, endDate);
-    
+
     // If a start date or an end date was specified, search temporal coverage
     //
     if (startDateSpecified || endDateSpecified) {
-    	String temporalFilter = null;
-    	String collectionFilter = null;
-    	String pubDateFilter = null;
+      String temporalFilter = null;
+      String collectionFilter = null;
+      String pubDateFilter = null;
 
       if (dateField.equals("ALL") || dateField.equals("COLLECTION")) {
-    	  String singleDateQuery = String.format("singledate:[%s+TO+%s]", startDate, endDate);
-    	  String startDateQuery = String.format("begindate:[*+TO+%s]", endDate);
-    	  String endDateQuery = String.format("enddate:[%s+TO+NOW]", startDate);
-    	  collectionFilter = String.format("(%s+OR+(%s+AND+%s))", singleDateQuery, startDateQuery, endDateQuery);
+        String singleDateQuery = String.format("singledate:[%s+TO+%s]", startDate, endDate);
+        String startDateQuery = String.format("begindate:[*+TO+%s]", endDate);
+        String endDateQuery = String.format("enddate:[%s+TO+NOW]", startDate);
+        collectionFilter = String.format("(%s+OR+(%s+AND+%s))", singleDateQuery, startDateQuery, endDateQuery);
       }
-      
+
       if (dateField.equals("ALL") || dateField.equals("PUBLICATION")) {
-    	  pubDateFilter = String.format("pubdate:[%s+TO+%s]", startDate, endDate);
+        pubDateFilter = String.format("pubdate:[%s+TO+%s]", startDate, endDate);
       }
-      
+
       if (dateField.equals("ALL")) {
-    	  temporalFilter = String.format("(%s+OR+%s)", pubDateFilter, collectionFilter);
+        temporalFilter = String.format("(%s+OR+%s)", pubDateFilter, collectionFilter);
+      } else if (dateField.equals("COLLECTION")) {
+        temporalFilter = collectionFilter;
+      } else if (dateField.equals("PUBLICATION")) {
+        temporalFilter = pubDateFilter;
       }
-      else if (dateField.equals("COLLECTION")) {
-    	  temporalFilter = collectionFilter;
-      }
-      else if (dateField.equals("PUBLICATION")) {
-    	  temporalFilter = pubDateFilter;
-      }
-      
-      updateFQString(temporalFilter);   
+
+      updateFQString(temporalFilter);
     }
 
   }
-  
-  
+
   /*
-   * Check whether a user's input date string conforms with one of the
-   * allowed formats as specified on the web form.
+   * Check whether a user's input date string conforms with one of the allowed
+   * formats as specified on the web form.
    */
   private String validateDateString(String dateString) {
     String returnValue = null;
@@ -523,36 +467,31 @@ public class SolrAdvancedSearch extends Search  {
     DateFormat dateFormat2 = new SimpleDateFormat("yyyy-MM");
     DateFormat dateFormat3 = new SimpleDateFormat("yyyy");
     Date date = null;
-    
+
     if (dateString == null || dateString.equals("")) {
       return dateString;
-    }
-    else {
+    } else {
       try {
         date = dateFormat1.parse(dateString);
         returnValue = dateFormat1.format(date);
-      }
-      catch (ParseException e1) {
+      } catch (ParseException e1) {
         try {
           date = dateFormat2.parse(dateString);
           returnValue = dateFormat2.format(date);
-        }
-        catch (ParseException e2) {
+        } catch (ParseException e2) {
           try {
             date = dateFormat3.parse(dateString);
             returnValue = dateFormat3.format(date);
-          }
-          catch (ParseException e3) {
+          } catch (ParseException e3) {
             logger.warn("Couldn't parse date string using any of the recognized formats: " + dateString);
-          }    
+          }
         }
       }
     }
-    
+
     return returnValue;
   }
-  
-  
+
   /*
    * Check whether a user's input date range is valid.
    */
@@ -560,34 +499,30 @@ public class SolrAdvancedSearch extends Search  {
     Date startDate = null;
     Date endDate = null;
     DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-    
+
     try {
       if ((startDateStr != null) && (endDateStr != null)) {
         startDate = dateFormat.parse(startDateStr);
         endDate = dateFormat.parse(endDateStr);
-      
+
         if ((startDate != null) && (endDate != null) && (startDate.after(endDate))) {
-          throw new IllegalArgumentException(
-            "The date range is invalid. Start date ('" + startDateStr + 
-            "') should be less than end date ('" + endDateStr + "').");   	
+          throw new IllegalArgumentException("The date range is invalid. Start date ('" + startDateStr
+              + "') should be less than end date ('" + endDateStr + "').");
         }
       }
-    }
-    catch (ParseException e) {
+    } catch (ParseException e) {
       logger.warn("Couldn't parse date string: " + e.getMessage());
     }
-    
+
   }
 
-
   /**
-   * A taxon query searches the taxonRankValue field,
-   * matching the field if the user-specified value is contained in the field.
+   * A taxon query searches the taxonRankValue field, matching the field if the
+   * user-specified value is contained in the field.
    */
-  private void buildQueryTaxon(TermsList termsList) 
-  		throws UnsupportedEncodingException {
+  private void buildQueryTaxon(TermsList termsList) throws UnsupportedEncodingException {
     final String value = this.taxon;
-      
+
     if ((value != null) && (!(value.equals("")))) {
       termsList.addTerm(value);
       String parenthesizedValue = parenthesizeQueryValue(value);
@@ -597,158 +532,140 @@ public class SolrAdvancedSearch extends Search  {
       updateQString(taxonQuery);
     }
   }
-  
 
-	/**
-	 * An identifier query searches the doi and packageid fields, matching the
-	 * field if the user-specified value is contained in the field.
-	 */
-	private void buildQueryIdentifier(TermsList termsList)
-			throws UnsupportedEncodingException {
-		String value = this.identifier;
+  /**
+   * An identifier query searches the doi and packageid fields, matching the field
+   * if the user-specified value is contained in the field.
+   */
+  private void buildQueryIdentifier(TermsList termsList) throws UnsupportedEncodingException {
+    String value = this.identifier;
 
-		if ((value != null) && (!(value.equals("")))) {
+    if ((value != null) && (!(value.equals("")))) {
 
-			termsList.addTerm(value);
+      termsList.addTerm(value);
 
-			/*
-			 * If the user entered a PASTA identifier, convert it to a packageId
-			 * value so that it will match the Solr 'packageid' field. (We don't
-			 * index the PASTA identifier in Solr.)
-			 */
-			String packageId = PastaClient.pastaURLtoPackageId(value);
-			if (packageId != null) {
-				value = packageId;
-			}
+      /*
+       * If the user entered a PASTA identifier, convert it to a packageId value so
+       * that it will match the Solr 'packageid' field. (We don't index the PASTA
+       * identifier in Solr.)
+       */
+      String packageId = PastaClient.pastaURLtoPackageId(value);
+      if (packageId != null) {
+        value = packageId;
+      }
 
-		    String parenthesizedValue = parenthesizeQueryValue(value);
-			String escapedValue = Search.escapeQueryChars(parenthesizedValue);
-			String encodedValue = URLEncoder.encode(escapedValue, "UTF-8");
-			String doiQuery = String.format("doi:%s", encodedValue);
-			updateQString(doiQuery);
-			String packageIdQuery = String.format("packageid:%s", encodedValue);
-			updateQString(packageIdQuery);
-			String idQuery = String.format("id:%s", encodedValue);
-			updateQString(idQuery);
-		}
-	}
-
+      String parenthesizedValue = parenthesizeQueryValue(value);
+      String escapedValue = Search.escapeQueryChars(parenthesizedValue);
+      String encodedValue = URLEncoder.encode(escapedValue, "UTF-8");
+      String doiQuery = String.format("doi:%s", encodedValue);
+      updateQString(doiQuery);
+      String packageIdQuery = String.format("packageid:%s", encodedValue);
+      updateQString(packageIdQuery);
+      String idQuery = String.format("id:%s", encodedValue);
+      updateQString(idQuery);
+    }
+  }
 
   /**
    * Build a site filter. If the AdvancedSearch's site value is non-null, add a
-   * query group that limits the results to a particular LTER site. Do this
-   * by searching for a packageId attribute that starts with "knb-lter-xyz"
-   * where "xyz" is the three-letter site acronym.
+   * query group that limits the results to a particular LTER site. Do this by
+   * searching for a packageId attribute that starts with "knb-lter-xyz" where
+   * "xyz" is the three-letter site acronym.
    */
-	private void buildQueryFilterSite(TermsList termsList) {
-		String attributeValue = "";
-		String siteQuery = "scope:(";
+  private void buildQueryFilterSite(TermsList termsList) {
+    String attributeValue = "";
+    String siteQuery = "scope:(";
 
-		if (this.siteValues != null) {
-			for (int i = 0; i < siteValues.length; i++) {
-				String site = siteValues[i];
-				LTERSite lterSite = new LTERSite(site);
-				if (lterSite.isValidSite()) {
-					attributeValue = lterSite.getPackageId();
-					String siteName = lterSite.getSiteName();
-					if ((siteName != null) && (!siteName.equals(""))) {
-						termsList.addTerm(siteName);
-					}
-				    String plusSign = (i > 0) ? "+" : "";
-					siteQuery = String.format("%s%s%s", siteQuery, plusSign, attributeValue);
-					if ((i + 1) == siteValues.length) { // tack on the closing parenthesis
-						siteQuery = String.format("%s)", siteQuery); 
-					}
-				}
-			}
-			
-			updateFQString(siteQuery);
-		}
-	}
+    if (this.siteValues != null) {
+      for (int i = 0; i < siteValues.length; i++) {
+        String site = siteValues[i];
+        LTERSite lterSite = new LTERSite(site);
+        if (lterSite.isValidSite()) {
+          attributeValue = lterSite.getPackageId();
+          String siteName = lterSite.getSiteName();
+          if ((siteName != null) && (!siteName.equals(""))) {
+            termsList.addTerm(siteName);
+          }
+          String plusSign = (i > 0) ? "+" : "";
+          siteQuery = String.format("%s%s%s", siteQuery, plusSign, attributeValue);
+          if ((i + 1) == siteValues.length) { // tack on the closing parenthesis
+            siteQuery = String.format("%s)", siteQuery);
+          }
+        }
+      }
 
+      updateFQString(siteQuery);
+    }
+  }
 
   /**
    * Boolean to determine whether the east/west coordinates of a spatial search
    * cross over the international date line.
-   * 
+   *
    * @param eastValue
    * @param westValue
    * @return true if the values cross the data line, else false.
    */
-  private boolean crossesInternationalDateline(String eastValue, 
-                                               String westValue
-                                               ) {
+  private boolean crossesInternationalDateline(String eastValue, String westValue) {
     boolean crosses = false;
-    
-    if ((eastValue != null) &&
-        (eastValue != "") &&
-        (westValue != null) &&
-        (westValue != "")
-       ) {
+
+    if ((eastValue != null) && (eastValue != "") && (westValue != null) && (westValue != "")) {
       Double eastInteger = new Double(eastValue);
       Double westInteger = new Double(westValue);
-      
+
       crosses = westInteger > eastInteger;
     }
-    
+
     logger.debug("crosses International Dateline: " + crosses);
-    
+
     return crosses;
   }
 
-  
-	/**
-	 * Builds and runs a search, returning the result XML string.
-	 * 
-	 * @param uid
-	 *            the user id
-	 */
-	public String executeSearch(final String uid) 
-			throws Exception {
-		buildQuerySubject(this.termsList);
-		buildQueryAuthor(this.termsList); 
-		buildQueryTaxon(this.termsList);
-		buildQueryIdentifier(this.termsList);
-		buildQueryGeographicDescription(this.locationName, this.termsList);
-		buildQueryFilterTemporal(this.dateField, this.startDate,
-		   this.endDate, this.isDatesContainedChecked, this.namedTimescale,
-		   this.namedTimescaleQueryType, this.termsList);
-		buildQueryFilterSite(this.termsList);
-		buildQueryFilterSpatial(this.northBound, this.southBound, this.eastBound,
-				 this.westBound, this.isBoundaryContainedChecked);
-	
-		queryString = String.format(
-				"defType=%s&q=%s&%s&fl=%s&debug=%s",
-				DEFAULT_DEFTYPE, this.qString.trim(), this.fqString.trim(),
-				DEFAULT_FIELDS, DEFAULT_DEBUG
-		);
+  /**
+   * Builds and runs a search, returning the result XML string.
+   *
+   * @param uid the user id
+   */
+  public String executeSearch(final String uid) throws Exception {
+    buildQuerySubject(this.termsList);
+    buildQueryAuthor(this.termsList);
+    buildQueryTaxon(this.termsList);
+    buildQueryIdentifier(this.termsList);
+    buildQueryGeographicDescription(this.locationName, this.termsList);
+    buildQueryFilterTemporal(this.dateField, this.startDate, this.endDate, this.isDatesContainedChecked,
+        this.namedTimescale, this.namedTimescaleQueryType, this.termsList);
+    buildQueryFilterSite(this.termsList);
+    buildQueryFilterSpatial(this.northBound, this.southBound, this.eastBound, this.westBound,
+        this.isBoundaryContainedChecked);
 
-		DataPackageManagerClient dpmClient = new DataPackageManagerClient(uid);
-		String extendedQueryString = String.format("%s&start=%d&rows=%d&sort=%s", queryString, DEFAULT_START, DEFAULT_ROWS, DEFAULT_SORT);
-		String resultsetXML = dpmClient.searchDataPackages(extendedQueryString);
-		logger.warn(String.format("query:\n%s", extendedQueryString));
+    queryString = String.format("defType=%s&q=%s&%s&fl=%s&debug=%s", DEFAULT_DEFTYPE, this.qString.trim(),
+        this.fqString.trim(), DEFAULT_FIELDS, DEFAULT_DEBUG);
 
-		return resultsetXML;
-	}
+    DataPackageManagerClient dpmClient = new DataPackageManagerClient(uid);
+    String extendedQueryString = String.format("%s&start=%d&rows=%d&sort=%s", queryString, DEFAULT_START, DEFAULT_ROWS,
+        DEFAULT_SORT);
+    String resultsetXML = dpmClient.searchDataPackages(extendedQueryString);
+    logger.warn(String.format("query:\n%s", extendedQueryString));
 
+    return resultsetXML;
+  }
 
-	/**
-	 * Accessor method for the queryString instance variable.
-	 * 
-	 * @return queryString
-	 */
-	public String getQueryString() {
-		return queryString;
-	}
+  /**
+   * Accessor method for the queryString instance variable.
+   *
+   * @return queryString
+   */
+  public String getQueryString() {
+    return queryString;
+  }
 
-
-	/**
-	 * Accessor method for the termsList instance variable.
-	 * 
-	 * @return termsList, a TermsList object
-	 */
-	public TermsList getTermsList() {
-		return termsList;
-	}
+  /**
+   * Accessor method for the termsList instance variable.
+   *
+   * @return termsList, a TermsList object
+   */
+  public TermsList getTermsList() {
+    return termsList;
+  }
 
 }


### PR DESCRIPTION
Added a SOLR filter query to both the simple and advanced searches to limit results to just the organization(s) we want to show.

**Global Changes**
* A static string was created in `Search.java` to hold a SOLR _filter query_ that limits results to only those packages whose organization name matches either `CAPLTER` or `CAP LTER`. This is a placeholder value, and will be changed for production. This just establishes the one place where this setting will live.
* Unwanted formatting changes thanks to an unexpected code formatter residing in the Java language pack plug-in. 

**For Simple Searches**
* Updated the existing SOLR query to include our new filter.

**For Advanced Searches**
* Updated the method that adds filter queries to always add our filter query
* Commented out the existing code for handling organization names, so that it would not conflict with our new filter