### PR TITLE
Default to CAPLTER Search via Scope

### DIFF
--- a/DataPortal2/src/edu/lternet/pasta/portal/search/Search.java
+++ b/DataPortal2/src/edu/lternet/pasta/portal/search/Search.java
@@ -23,6 +23,7 @@ public class Search {
 	protected final static String ECOTRENDS_FILTER = "-scope:ecotrends";
 	protected final static String LANDSAT_FILTER = "-scope:lter-landsat*";
 	public final static String GIOS_FILTER = "organization:(\"CAPLTER\") OR organization:(\"CAP LTER\")";
+	public final static String CAP_FILTER = "scope:knb-lter-cap";
 	protected final static String DEFAULT_FIELDS = "id,packageid,title,author,organization,pubdate,coordinates";
 	public final static int DEFAULT_START = 0;
 	public final static int DEFAULT_ROWS = 10;

--- a/DataPortal2/src/edu/lternet/pasta/portal/search/SimpleSearch.java
+++ b/DataPortal2/src/edu/lternet/pasta/portal/search/SimpleSearch.java
@@ -90,7 +90,8 @@ public class SimpleSearch extends Search {
 
 			// supply a filter query to limit our search to just the organization(s) we want
 			try {
-				giosEncodedFilter = URLEncoder.encode(GIOS_FILTER, "UTF-8");
+				//giosEncodedFilter = URLEncoder.encode(GIOS_FILTER, "UTF-8");
+				giosEncodedFilter = URLEncoder.encode(CAP_FILTER, "UTF-8");
 			} catch (UnsupportedEncodingException e) {
 
 			}

--- a/DataPortal2/src/edu/lternet/pasta/portal/search/SolrAdvancedSearch.java
+++ b/DataPortal2/src/edu/lternet/pasta/portal/search/SolrAdvancedSearch.java
@@ -165,7 +165,7 @@ public class SolrAdvancedSearch extends Search {
     // always add a query filter to limit results to our desired organization(s)
     try {
       // our filter contains reserved characters, so URL encode them
-      giosEncodedFilter = URLEncoder.encode(GIOS_FILTER, "UTF-8");
+      giosEncodedFilter = URLEncoder.encode(CAP_FILTER, "UTF-8");
     } catch (UnsupportedEncodingException e) {
 
     }


### PR DESCRIPTION
Change the default method of searching for datasets to use a scope, and not an organization name. Scopes are defined values (such as 'knb-lter-cap') that we can expect to be consistent, whereas organization names are user-entered, and may not always result in exact matches.