### PR TITLE
Some Post-Launch Cosmetic Fixes

### DIFF
--- a/DataPortal2/WebRoot/css/gios.css
+++ b/DataPortal2/WebRoot/css/gios.css
@@ -70,13 +70,18 @@ Menu
  * and remove the padding inside the navbar itself (this gives us 'full-height' rollover states). Removing that
  * padding messes up the placement of the menu items, so we change the line height to move them down
  */
- .navbar {
-    height: 56px;
+
+.asu-menu {
+  background-color: #353535;
+}
+
+.navbar {
+    height: 57px;
     padding: 0;
 }
 
 .navbar-nav {
-    height: 56px;
+    height: 57px;
     line-height: 2.5em;
 }
 
@@ -84,7 +89,8 @@ Menu
     padding-left: .5em;
     padding-right: .5em;
     font-size: .9375rem;
-    font-weight: 700;
+    font-weight: 500;
+    color: white;
 }
 
 .nav-item:hover {

--- a/DataPortal2/WebRoot/header.jsp
+++ b/DataPortal2/WebRoot/header.jsp
@@ -92,7 +92,7 @@
 				<div class="collapse navbar-collapse" id="navbarSupportedContent">
 					<ul class="navbar-nav mr-auto">
 						<li class="nav-item home-icon">
-							<a class="nav-link" href="home.jsp"><span class="fas fa-home"></span></a>
+							<a class="nav-link" href="https://sustainability.asu.edu/"><span class="fas fa-home"></span></a>
 						</li>
 						<li class="nav-item">
 							<a class="nav-link" href="https://sustainability.asu.edu/people/">People</a>
@@ -120,9 +120,6 @@
 						</li>
 						<li class="nav-item">
 							<a class="nav-link" href="https://sustainability.asu.edu/about/">About</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="https://sustainability.asu.edu/contact/">Contact</a>
 						</li>
 				</div>
 			</nav>

--- a/DataPortal2/WebRoot/header.jsp
+++ b/DataPortal2/WebRoot/header.jsp
@@ -77,14 +77,14 @@
 %>
 <header role="banner">
 	<!-- Bootstrap NavBar -->
-	<div class="container-fluid  bg-dark d-lg-none">
+	<div class="container-fluid asu-menu d-lg-none">
 			<div id="mobile-nav-header" class="navbar-header">
-				<a class="navbar-brand" href="home.jsp">GIOS Data Portal</a>
+				<a class="navbar-brand asu-menu" href="https://data.sustainability.asu.edu/dataportal/home.jsp">GIOS Data Portal</a>
 			</div>
 	</div>
-	<div class="container-fluid bg-dark">
+	<div class="container-fluid asu-menu">
 		<div class="container">
-			<nav class="navbar d-none d-lg-block navbar-expand-lg navbar-dark bg-dark" id="gios-nav">
+			<nav class="navbar d-none d-lg-block navbar-expand-lg navbar-dark asu-menu" id="gios-nav">
 				<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
 					<span class="navbar-toggler-icon"></span>
 				</button>

--- a/DataPortal2/WebRoot/home.jsp
+++ b/DataPortal2/WebRoot/home.jsp
@@ -86,7 +86,7 @@
 		<div class="col-7" style="font-weight: 300; font-size: 18px;">
 			<h1>About The GIOS Data Portal</h1>
 
-			<p>The GIOS Data Portal is the main resource for the discovery and download of datasets created by GIOS scientists and scholars. With the GIOS Data Portal you can:</p>
+			<p>The GIOS Data Portal is the main resource for the discovery and download of datasets published by GIOS scientists and scholars. With the GIOS Data Portal you can:</p>
 				<ul>
 					<li>Quickly search for datasets based on keywords or author names</li>
 					<li>Create more granular searches using the <a href="advancedSearch.jsp">advanced search</a> features</li>

--- a/DataPortal2/WebRoot/home.jsp
+++ b/DataPortal2/WebRoot/home.jsp
@@ -95,7 +95,7 @@
 					<li>Generate code to use datasets in Python, R, and other languages</li>
 				</ul>
 
-			<p>The GIOS Data Portal is a modified version of <a href="https://portal.edirepository.org/nis/home.jsp" target="_blank">the EDI Data Portal</a> - it is powered by the same technology, and searches the same EDI database, but is filtered to only include datasets that originate from GIOS scientists and scholars.
+			<p>The GIOS Data Portal is a modified version of <a href="https://portal.edirepository.org/nis/home.jsp" target="_blank">the Environmental Data Initiative (EDI) Data Portal</a> - it is powered by the same technology, and searches the same EDI database, but is filtered to only include datasets published by GIOS scientists and scholars.
 		</div>
 		<div class="col">
 			<img class="img-100" src="images/portal-graphic-01.svg" alt="placeholder">


### PR DESCRIPTION
This includes some small changes to better match the GIOS site, as well as new language suggested by Phil. To wit:

* Proper menu background color to match the GIOS site
* New font weight on menu items to (better) match the GIOS site
* Consistent use of the word 'publish' when referring to datasets from our GIOS scientists and scholars
* Point home link on data portal to the GIOS home page (rather than the data portal home page)